### PR TITLE
camal case ?

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,36 +4,34 @@ use clap::{App, Arg};
 
 arg_enum! {
     #[derive(Debug)]
-    enum Method
-    {
-        install,
-        remove
+    enum Method {
+        Install,
+        Remove
     }
 }
 
 fn main() {
     let arg_matches = App::new("wiz")
-                        .version("0.1.0")
+        .version("0.1.0")
                           
-                        .arg(Arg::with_name("method")
-                            .help("Specify what to do with the specified package")
-                            .index(1)
-                            .possible_values(&Method::variants())
-                            .required(true))
+        .arg(Arg::with_name("method")
+             .help("Specify what to do with the specified package")
+             .index(1)
+             .possible_values(&Method::variants())
+             .required(true))
                                         
-                        .arg(Arg::with_name("package")
-                            .help("Specify package")
-                            .index(2)
-                            .required(true))
-
-                        .get_matches();
-
+        .arg(Arg::with_name("package")
+             .help("Specify package")
+             .index(2)
+             .required(true))
+        
+        .get_matches();
 
     let method = value_t!(arg_matches.value_of("method"), Method).unwrap();
     let package = arg_matches.value_of("package").unwrap_or("invalid");
 
     match method {
-        Method::install => println!("install: {}", package),
-        Method::remove => println!("remove: {}", package)
+        Method::Install => println!("install: {}", package),
+        Method::Remove => println!("remove: {}", package)
     }
 }


### PR DESCRIPTION
I think we should use the Camal Case as rustc recommended.
Although `#[warn(non_camal_case_types)]` compiler flag will works too
